### PR TITLE
CopyZipsFunction update to python 3.7

### DIFF
--- a/templates/control-tower-customization.yml
+++ b/templates/control-tower-customization.yml
@@ -123,7 +123,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.7
       Role: !GetAtt 'CopyZipsRole.Arn'
       Timeout: 240
       Code:


### PR DESCRIPTION
Update  function `CopyZipsFunction` to use python 3.7